### PR TITLE
slight regex change, tests to prove utils works

### DIFF
--- a/shared_code/utils.py
+++ b/shared_code/utils.py
@@ -41,7 +41,7 @@ def insert_services(data, client, collection):
 
 
 def check_similarity(new_service, existing_service):
-    regex = r'(st\.? |saint | inc\.?| nfp)'
+    regex = r'(\bst\.?\b|\bsaint\b|\binc\.?\b| nfp)'
     new_subbed_service = re.sub(regex, '', new_service).lower()
     existing_subbed_service = re.sub(regex, '', existing_service).lower()
     return distance(new_subbed_service, existing_subbed_service) >= 0.9

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,90 @@
+import mongomock
+import pytest
+from dotenv import load_dotenv
+import os
+from shared_code.utils import (
+    make_ngrams, distance, insert_services, check_similarity,
+    locate_potential_duplicate, refresh_ngrams, get_mongo_client
+)
+
+from pymongo import MongoClient
+
+'''
+Assumes ngram and distance works as proved in IRS_test.py
+'''
+load_dotenv()
+
+@pytest.fixture
+def mock_mongo_client():
+    return mongomock.MongoClient()
+
+@pytest.fixture
+def shelter_db():
+    return MongoClient("mongodb+srv://" + os.environ.get("DB_USER") + ":" + os.environ.get("DB_PASS") + "@shelter-rm3lc.azure.mongodb.net/shelter?retryWrites=true&w=majority")['shelter']
+
+@pytest.fixture
+def test_scraper_data():
+    return [{"_id":"6017e08548cc6486984de5f6","name":"Baxley City Gym","notes":"Open","address1":"69 Tippins Street Baxley, GA 31513","city":"Baxley","state":"GA","zip":"31513","phone":"(912)-339-0072","country":"US","source":"summer_meal_sites"},
+     {"_id":"6017e08548cc6486984de5d5","name":"Crossroads Baptists Church","notes":"Open","address1":"243 Marshall Mill Road Fort Valley, GA 31030","city":"Fort Valley","state":"GA","zip":"31030","phone":"(478)-836-4546","country":"US","source":"summer_meal_sites"},
+     {"_id":"6017e08548cc6486984de5e0","name":"Crossroads Community Parks","notes":"Open","address1":"243 Marshall Mill Road Fort Valley, GA 31030","city":"Fort Valley","state":"GA","zip":"31030","phone":"(478)-836-4546","country":"US","source":"summer_meal_sites"}]
+
+@pytest.fixture
+def test_services_data():
+    return [{"_id":"6017e08548cc6486984de5a2","name":"Crossroads Baptist Church","notes":"Open","address1":"243 Marshall Mill Road Fort Valley, GA 31030","city":"Fort Valley","state":"GA","zip":"31030","phone":"(478)-836-4546","country":"US","source":"summer_meal_sites"},
+     {"_id":"6017e08548cc6486984de5a3","name":"Crossroads Community Park","notes":"Open","address1":"243 Marshall Mill Road Fort Valley, GA 31030","city":"Fort Valley","state":"GA","zip":"31030","phone":"(478)-836-4546","country":"US","source":"summer_meal_sites"}]
+
+
+def test_insert_services(test_scraper_data, mock_mongo_client):
+    insert_services(test_scraper_data, mock_mongo_client.shelter, 'tmpTestScraper')
+    found_services = [obj for obj in mock_mongo_client.shelter.tmpTestScraper.find({})]
+    assert test_scraper_data == found_services
+
+
+def test_refresh_ngrams(test_services_data,mock_mongo_client):
+    insert_services(test_services_data, mock_mongo_client.shelter, 'services')
+    refresh_ngrams(mock_mongo_client.shelter,'services')
+    assert mock_mongo_client.shelter.services.find_one({"name":"Crossroads Baptist Church"})["ngrams"] == ' '.join(make_ngrams('Crossroads Baptist Church'.upper()))
+
+def test_check_similarity():
+    assert distance('Crossroads Baptists Church', 'Crossroads Baptist Church') >= .9
+    assert check_similarity('Crossroads Baptists Church', 'Crossroads Baptist Church')
+
+
+def test_locate_potential_duplicate(test_scraper_data,test_services_data, shelter_db):
+    tmp_test_scraper_coll = shelter_db['tmpTestScraper']
+    test_services_coll = shelter_db['testServices']
+
+    try:
+        test_services_coll.insert_many(test_services_data)
+        refresh_ngrams(shelter_db,'testServices')
+
+        #Crossroads Baptist Church
+        doc = test_scraper_data[1]
+        assert check_similarity(doc['name'], test_services_data[0]['name'])
+        assert locate_potential_duplicate(doc['name'], doc['zip'], shelter_db, 'testServices')
+
+
+
+        doc = test_scraper_data[2]
+        ngrams_match = False
+        for ngram in make_ngrams(doc['name']):
+            if ngram in make_ngrams(test_services_data[0]['name']):
+                ngrams_match = True
+                break
+
+        assert ngrams_match
+
+        assert check_similarity(doc['name'], test_services_data[1]['name'])
+
+        assert not check_similarity(doc['name'], test_services_data[0]['name'])
+
+        located_dupe_name = locate_potential_duplicate(doc['name'], doc['zip'], shelter_db, 'testServices')
+        assert located_dupe_name
+        assert check_similarity(located_dupe_name, doc['name'])
+
+    except Exception as e:
+        test_services_coll.drop()
+        raise(e)
+
+
+    test_services_coll.drop()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,7 +84,9 @@ def test_locate_potential_duplicate(test_scraper_data,test_services_data, shelte
 
     except Exception as e:
         test_services_coll.drop()
+        tmp_test_scraper_coll.drop()
         raise(e)
 
 
     test_services_coll.drop()
+    tmp_test_scraper_coll.drop()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,8 +46,17 @@ def test_refresh_ngrams(test_services_data,mock_mongo_client):
     assert mock_mongo_client.shelter.services.find_one({"name":"Crossroads Baptist Church"})["ngrams"] == ' '.join(make_ngrams('Crossroads Baptist Church'.upper()))
 
 def test_check_similarity():
+    #Positive test
     assert distance('Crossroads Baptists Church', 'Crossroads Baptist Church') >= .9
     assert check_similarity('Crossroads Baptists Church', 'Crossroads Baptist Church')
+
+    #Negative test
+    assert distance('st. Paul Church House', 'saint Paul Church House') < .9
+    assert check_similarity('st. Paul Church House', 'saint Paul Church House')
+
+    #Negative Test
+    assert distance('St. Paul Church House', 'Saint Paul Church House') < .9
+    assert check_similarity('St. Paul Church House', 'Saint Paul Church House')
 
 
 def test_locate_potential_duplicate(test_scraper_data,test_services_data, shelter_db):


### PR DESCRIPTION
Looks like utils works correctly, I thought "coll.find_one(
        {"$text": {"$search": ' '.join(grammed_name)}, 'zip': zipcode}
    )"  would search using logical or until it found the first ngram match, but it seems to actually find the closest match (longest string) if anyone can confirm that would be awesome, but it looks like the tests prove it.

Also made a slight regex change, and wrote corresponding test to show why (not sure how I should link those two things to make it easy to review)